### PR TITLE
Make the entry order configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ The function is called using the same context as the loader, so everything [here
 You can also pass in more options:
 
 ```javascript
+import InjectPlugin, { ENTRY_ORDER } from 'webpack-inject-plugin';
 
 new InjectPlugin(loader, {
-    entry: 'entry name'     // The name of the entry to inject code into, if multiple are used
-})
+    entry: 'entry name',         //  Limit the injected code to only the entry w/ this name
+    order:  ENTRY_ORDER.First    //  Make the injected code be the first entry point
+            ENTRY_ORDER.Last     //  Make the injected code be the last entry point
+            ENTRY_ORDER.NotLast  //  Make the injected code be second to last. (The last entry module is the API of the bundle. Useful when you don't want to override that.) This is the default.
+});
 
 ```
 

--- a/src/__tests__/main.js
+++ b/src/__tests__/main.js
@@ -17,12 +17,47 @@ test('appends to the entry config correctly', t => {
 });
 
 test('appends to only the specified entry', t => {
-  t.is(injectEntry(undefined, 'foo', 'bar'), 'foo');
+  t.is(injectEntry(undefined, 'foo', {entryName: 'bar'}), 'foo');
   t.deepEqual(injectEntry({
     foo: 'bar',
     bar: 'baz'
-  }, 'added', 'bar'), {
+  }, 'added', {entryName: 'bar'}), {
     foo: 'bar',
     bar: ['added', 'baz']
   });
+});
+
+test('respects config for order', t => {
+  t.deepEqual(injectEntry([
+    'foo',
+    'bar'
+  ], 'baz', {entryOrder: 'first'}), [
+    'baz',
+    'foo',
+    'bar'
+  ]);
+
+  t.deepEqual(injectEntry([
+    'foo',
+    'bar'
+  ], 'baz', {entryOrder: 'last'}), [
+    'foo',
+    'bar',
+    'baz'
+  ]);
+
+  t.deepEqual(injectEntry([
+    'foo',
+    'bar'
+  ], 'baz', {entryOrder: 'notLast'}), [
+    'foo',
+    'baz',
+    'bar'
+  ]);
+});
+
+test('order config for strings', t => {
+  t.deepEqual(injectEntry('original', 'new', {entryOrder: 'first'}), ['new', 'original']);
+  t.deepEqual(injectEntry('original', 'new', {entryOrder: 'last'}), ['original', 'new']);
+  t.deepEqual(injectEntry('original', 'new', {entryOrder: 'notLast'}), ['new', 'original']);
 });


### PR DESCRIPTION
Allows a user to specify the injection point of the code in the entry array. 

One of:
- `First`: Make the injected code the first entry point
- `Last`: Make the injected code the last entry (also the API for the bundle)
- `NotLast` (**current default**): Make the injected code the second to last entry point. (doesn't change the bundle's API, and also loads after any polyfill entry)


```javascript
import InjectPlugin, { ENTRY_ORDER } from 'webpack-inject-plugin';

new InjectPlugin(loader, {
    order:  ENTRY_ORDER.First || ENTRY_ORDER.Last || ENTRY_ORDER.NotLast 
    // or the string values
    order: 'first' || 'last' || 'notLast'
});

```

Closes #5 