### PR TITLE
fix: entryOrder First

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ function getUniqueID() {
 }
 
 export const enum ENTRY_ORDER {
-  First,
+  First = 1,
   Last,
   NotLast
 }


### PR DESCRIPTION
@adierkens had an issue since enums start at `0` this check right here wasn't passing https://github.com/adierkens/webpack-inject-plugin/blob/1adf82272a6a3a4ba62a84a56c5fc52959c19710/src/main.ts#L121

Two options: Check for undefined or just start enum at `1`.