### PR TITLE
Fix async and dynamic entry functions

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1,3 +1,4 @@
+import { EntryFunc } from 'webpack';
 import { injectEntry, ENTRY_ORDER } from '../main';
 
 describe('injectEntry', () => {
@@ -33,13 +34,20 @@ describe('injectEntry', () => {
       foo: ['added', 'bar'],
       another: ['an', 'added', 'array']
     });
-    expect(
-      injectEntry(
-        () => ({ foo: 'bar' }),
-        'added',
-        {}
-      )
-    ).toEqual({ foo: ['added', 'bar'] });
+
+    // This dynamic entry function will return {foo: bar} on first call, then {foo: baz} on the next call
+    let first = true;
+    const entryFunc = injectEntry(
+      async () => {
+        return { foo: first ? 'bar' : 'baz' };
+      },
+      'added',
+      {}
+    ) as EntryFunc;
+
+    expect(entryFunc()).resolves.toEqual({ foo: ['added', 'bar'] });
+    first = false;
+    expect(entryFunc()).resolves.toEqual({ foo: ['added', 'baz'] });
   });
 
   it('appends to only the specified entry', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,13 +94,15 @@ export function injectEntry(
   }
 
   if (typeof originalEntry === 'function') {
-    const callbackOriginEntry = originalEntry();
-    if (callbackOriginEntry instanceof Promise) {
-      // Can't handle Promise
-      return originalEntry;
-    }
+    // The entry function is meant to be called on each compilation (when using --watch, webpack-dev-server)
+    // We wrap the original function in our own function to reflect this behavior.
+    return async () => {
+      const callbackOriginEntry = await originalEntry();
 
-    return injectEntry(callbackOriginEntry, newEntry, options);
+      // Safe type-cast here because callbackOriginEntry cannot be an EntryFunc,
+      // so the injectEntry call won't return one either.
+      return injectEntry(callbackOriginEntry, newEntry, options) as Exclude<EntryType, EntryFunc>
+    };
   }
 
   if (Object.prototype.toString.call(originalEntry).slice(8, -1) === 'Object') {


### PR DESCRIPTION
If the entry is a function webpack calls that function on each compilation (this allows dynamic entries when using --watch and webpack-dev-server).

The existing logic would just call the function immediately and then discard it.

This PR wraps the entry function in a new function, fixing this problem.  It also adds support for async entry functions.