### PR TITLE
Moving @types to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -694,6 +694,7 @@
       "version": "1.1.3",
       "resolved": "http://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.3.tgz",
       "integrity": "sha512-euKGFr2oCB3ASBwG39CYJMR3N9T0nanVqXdiH7Zu/Nqddt6SmFRxytq/i2w9LQYNQekEtGBz+pE3qG6fQTNvRg==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/webpack": "*"
@@ -702,7 +703,8 @@
     "@types/node": {
       "version": "10.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-      "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
+      "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -713,12 +715,14 @@
     "@types/tapable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
-      "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ=="
+      "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==",
+      "dev": true
     },
     "@types/uglify-js": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
       "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+      "dev": true,
       "requires": {
         "source-map": "^0.6.1"
       },
@@ -726,7 +730,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -734,6 +739,7 @@
       "version": "4.4.17",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.17.tgz",
       "integrity": "sha512-f8fHYEhlrSQJ5BHaonyatL11MYwqQ7I6QDVCT41LqIyxR7j9B2uY4cQKxDoWFC9l2NbFGsIhiJBKZ6Y6LMBFLA==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/tapable": "*",
@@ -744,7 +750,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,7 +1219,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.intuit.net/a/ansi-styles/_attachments/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/a/ansi-styles/_attachments/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -1228,7 +1228,7 @@
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": "https://registry.npmjs.intuit.net/c/chalk/_attachments/chalk-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/c/chalk/_attachments/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
@@ -1239,13 +1239,13 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.intuit.net/h/has-flag/_attachments/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/h/has-flag/_attachments/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.intuit.net/p/pify/_attachments/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p/pify/_attachments/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
@@ -1274,13 +1274,13 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/a/ansi-regex/_attachments/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/a/ansi-regex/_attachments/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/a/ansi-styles/_attachments/ansi-styles-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/a/ansi-styles/_attachments/ansi-styles-3.1.0.tgz",
       "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
       "dev": true,
       "requires": {
@@ -1596,7 +1596,7 @@
     },
     "argparse": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.intuit.net/a/argparse/_attachments/argparse-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/a/argparse/_attachments/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
@@ -1611,7 +1611,7 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/a/arr-flatten/_attachments/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/a/arr-flatten/_attachments/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
@@ -1662,13 +1662,13 @@
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/a/arrify/_attachments/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/a/arrify/_attachments/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.intuit.net/a/asn1/_attachments/asn1-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/a/asn1/_attachments/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
@@ -1711,7 +1711,7 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/a/assert-plus/_attachments/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/a/assert-plus/_attachments/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
@@ -1729,7 +1729,7 @@
     },
     "async": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.intuit.net/a/async/_attachments/async-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/a/async/_attachments/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
@@ -1746,7 +1746,7 @@
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/a/async-each/_attachments/async-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/a/async-each/_attachments/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
@@ -1758,7 +1758,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.intuit.net/a/asynckit/_attachments/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/a/asynckit/_attachments/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
@@ -1915,13 +1915,13 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.intuit.net/a/aws-sign2/_attachments/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/a/aws-sign2/_attachments/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.intuit.net/a/aws4/_attachments/aws4-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/a/aws4/_attachments/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
@@ -2054,7 +2054,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/b/balanced-match/_attachments/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/b/balanced-match/_attachments/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -2133,7 +2133,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/b/bcrypt-pbkdf/_attachments/bcrypt-pbkdf-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/b/bcrypt-pbkdf/_attachments/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
       "optional": true,
@@ -2172,7 +2172,7 @@
     },
     "brace-expansion": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.intuit.net/b/brace-expansion/_attachments/brace-expansion-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/b/brace-expansion/_attachments/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
@@ -2372,7 +2372,7 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/b/builtin-modules/_attachments/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/b/builtin-modules/_attachments/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
@@ -2510,13 +2510,13 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.intuit.net/c/caseless/_attachments/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/c/caseless/_attachments/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/c/chalk/_attachments/chalk-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/c/chalk/_attachments/chalk-2.0.1.tgz",
       "integrity": "sha1-2+xJQ20q4V9TYRTnbRRlbNvA9E0=",
       "dev": true,
       "requires": {
@@ -2527,7 +2527,7 @@
     },
     "chardet": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.intuit.net/c/chardet/_attachments/chardet-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/c/chardet/_attachments/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
@@ -2773,7 +2773,7 @@
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/c/cli-cursor/_attachments/cli-cursor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/c/cli-cursor/_attachments/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
@@ -2817,13 +2817,13 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.intuit.net/c/co/_attachments/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/c/co/_attachments/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/c/code-point-at/_attachments/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/c/code-point-at/_attachments/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
@@ -2839,7 +2839,7 @@
     },
     "color-convert": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.intuit.net/c/color-convert/_attachments/color-convert-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/c/color-convert/_attachments/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
@@ -2848,13 +2848,13 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.intuit.net/c/color-name/_attachments/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/c/color-name/_attachments/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.intuit.net/c/combined-stream/_attachments/combined-stream-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/c/combined-stream/_attachments/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
@@ -2945,7 +2945,7 @@
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/c/commondir/_attachments/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/c/commondir/_attachments/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
@@ -2963,7 +2963,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/c/concat-map/_attachments/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/c/concat-map/_attachments/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -3025,13 +3025,13 @@
     },
     "core-js": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.intuit.net/c/core-js/_attachments/core-js-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/c/core-js/_attachments/core-js-2.4.1.tgz",
       "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/c/core-util-is/_attachments/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/c/core-util-is/_attachments/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
@@ -3166,7 +3166,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.intuit.net/d/dashdash/_attachments/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/d/dashdash/_attachments/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -3220,7 +3220,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.intuit.net/d/decamelize/_attachments/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/decamelize/_attachments/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -3244,7 +3244,7 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.intuit.net/d/deep-is/_attachments/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/d/deep-is/_attachments/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -3327,7 +3327,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/d/delayed-stream/_attachments/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/delayed-stream/_attachments/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -3446,7 +3446,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/e/ecc-jsbn/_attachments/ecc-jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/e/ecc-jsbn/_attachments/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
       "optional": true,
@@ -3483,7 +3483,7 @@
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/e/emojis-list/_attachments/emojis-list-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/e/emojis-list/_attachments/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "end-of-stream": {
@@ -3526,7 +3526,7 @@
     },
     "error-ex": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.intuit.net/e/error-ex/_attachments/error-ex-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/e/error-ex/_attachments/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
@@ -3560,7 +3560,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.intuit.net/e/escape-string-regexp/_attachments/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/e/escape-string-regexp/_attachments/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -3984,7 +3984,7 @@
     },
     "esprima": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/e/esprima/_attachments/esprima-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/e/esprima/_attachments/esprima-4.0.0.tgz",
       "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
@@ -4008,13 +4008,13 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.intuit.net/e/estraverse/_attachments/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/e/estraverse/_attachments/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/e/esutils/_attachments/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/e/esutils/_attachments/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
@@ -4042,7 +4042,7 @@
     },
     "execa": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.intuit.net/e/execa/_attachments/execa-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/e/execa/_attachments/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
@@ -4063,7 +4063,7 @@
     },
     "exit-hook": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/e/exit-hook/_attachments/exit-hook-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/e/exit-hook/_attachments/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
@@ -4135,7 +4135,7 @@
     },
     "extend": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/e/extend/_attachments/extend-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/e/extend/_attachments/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
@@ -4162,7 +4162,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.intuit.net/e/external-editor/_attachments/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/e/external-editor/_attachments/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -4244,13 +4244,13 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.intuit.net/e/extsprintf/_attachments/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/e/extsprintf/_attachments/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/f/fast-deep-equal/_attachments/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/f/fast-deep-equal/_attachments/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
@@ -4262,13 +4262,13 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/f/fast-json-stable-stringify/_attachments/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/f/fast-json-stable-stringify/_attachments/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.intuit.net/f/fast-levenshtein/_attachments/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/f/fast-levenshtein/_attachments/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -4283,7 +4283,7 @@
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/f/figures/_attachments/figures-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/f/figures/_attachments/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
@@ -4334,7 +4334,7 @@
     },
     "find-cache-dir": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/f/find-cache-dir/_attachments/find-cache-dir-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/f/find-cache-dir/_attachments/find-cache-dir-1.0.0.tgz",
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
@@ -4360,7 +4360,7 @@
     },
     "find-up": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/f/find-up/_attachments/find-up-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/f/find-up/_attachments/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
@@ -4421,19 +4421,19 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/f/for-in/_attachments/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/f/for-in/_attachments/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.intuit.net/f/forever-agent/_attachments/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/f/forever-agent/_attachments/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.intuit.net/f/form-data/_attachments/form-data-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/f/form-data/_attachments/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
@@ -4475,7 +4475,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/f/fs.realpath/_attachments/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/f/fs.realpath/_attachments/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -5041,7 +5041,7 @@
     },
     "get-caller-file": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/g/get-caller-file/_attachments/get-caller-file-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/g/get-caller-file/_attachments/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
@@ -5099,7 +5099,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/g/get-stream/_attachments/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/g/get-stream/_attachments/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -5111,7 +5111,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.intuit.net/g/getpass/_attachments/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/g/getpass/_attachments/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -5147,7 +5147,7 @@
     },
     "glob": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.intuit.net/g/glob/_attachments/glob-7.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/g/glob/_attachments/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
@@ -5223,7 +5223,7 @@
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://registry.npmjs.intuit.net/g/graceful-fs/_attachments/graceful-fs-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/g/graceful-fs/_attachments/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
@@ -5255,13 +5255,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/h/har-schema/_attachments/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/h/har-schema/_attachments/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.intuit.net/h/har-validator/_attachments/har-validator-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/h/har-validator/_attachments/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
@@ -5271,7 +5271,7 @@
       "dependencies": {
         "ajv": {
           "version": "5.5.2",
-          "resolved": "https://registry.npmjs.intuit.net/a/ajv/_attachments/ajv-5.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/a/ajv/_attachments/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
@@ -5294,7 +5294,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/h/has-ansi/_attachments/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/h/has-ansi/_attachments/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -5303,7 +5303,7 @@
     },
     "has-flag": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/h/has-flag/_attachments/has-flag-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/h/has-flag/_attachments/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
@@ -5406,7 +5406,7 @@
     },
     "hosted-git-info": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.intuit.net/h/hosted-git-info/_attachments/hosted-git-info-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/h/hosted-git-info/_attachments/hosted-git-info-2.5.0.tgz",
       "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
@@ -5421,7 +5421,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.intuit.net/h/http-signature/_attachments/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/h/http-signature/_attachments/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -5686,13 +5686,13 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.intuit.net/i/imurmurhash/_attachments/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/i/imurmurhash/_attachments/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/indent-string/_attachments/indent-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/indent-string/_attachments/indent-string-3.1.0.tgz",
       "integrity": "sha1-CP9DNGAziDmbMp5rlTjcejz13n0=",
       "dev": true
     },
@@ -5704,7 +5704,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.intuit.net/i/inflight/_attachments/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/i/inflight/_attachments/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -5714,7 +5714,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.intuit.net/i/inherits/_attachments/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/i/inherits/_attachments/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
@@ -5763,7 +5763,7 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/invert-kv/_attachments/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/invert-kv/_attachments/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
@@ -5778,13 +5778,13 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-arrayish/_attachments/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-arrayish/_attachments/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-binary-path/_attachments/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-binary-path/_attachments/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -5793,13 +5793,13 @@
     },
     "is-buffer": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-buffer/_attachments/is-buffer-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-buffer/_attachments/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-builtin-module/_attachments/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-builtin-module/_attachments/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -5863,7 +5863,7 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-extendable/_attachments/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-extendable/_attachments/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
@@ -5875,7 +5875,7 @@
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-finite/_attachments/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-finite/_attachments/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -5884,7 +5884,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-fullwidth-code-point/_attachments/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-fullwidth-code-point/_attachments/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
@@ -5914,7 +5914,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-obj/_attachments/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-obj/_attachments/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -5937,7 +5937,7 @@
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-promise/_attachments/is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-promise/_attachments/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
@@ -5970,7 +5970,7 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-stream/_attachments/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-stream/_attachments/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
@@ -5985,7 +5985,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/is-typedarray/_attachments/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/is-typedarray/_attachments/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
@@ -6003,13 +6003,13 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/isarray/_attachments/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/isarray/_attachments/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/i/isexe/_attachments/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/i/isexe/_attachments/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -6021,7 +6021,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.intuit.net/i/isstream/_attachments/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/i/isstream/_attachments/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
@@ -7475,7 +7475,7 @@
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/j/js-tokens/_attachments/js-tokens-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/j/js-tokens/_attachments/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
@@ -7491,7 +7491,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/j/jsbn/_attachments/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/j/jsbn/_attachments/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
@@ -7544,13 +7544,13 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.intuit.net/j/json-schema/_attachments/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/j/json-schema/_attachments/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.intuit.net/j/json-schema-traverse/_attachments/json-schema-traverse-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/j/json-schema-traverse/_attachments/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
@@ -7562,7 +7562,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/j/json-stringify-safe/_attachments/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/j/json-stringify-safe/_attachments/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -7585,7 +7585,7 @@
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.intuit.net/j/jsprim/_attachments/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/j/jsprim/_attachments/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -7603,7 +7603,7 @@
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.intuit.net/k/kind-of/_attachments/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/k/kind-of/_attachments/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
@@ -7618,7 +7618,7 @@
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/l/lcid/_attachments/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/l/lcid/_attachments/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -7639,7 +7639,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.intuit.net/l/levn/_attachments/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/l/levn/_attachments/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -8363,7 +8363,7 @@
     },
     "locate-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/l/locate-path/_attachments/locate-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/l/locate-path/_attachments/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
@@ -8391,7 +8391,7 @@
     },
     "lodash.debounce": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.intuit.net/l/lodash.debounce/_attachments/lodash.debounce-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/l/lodash.debounce/_attachments/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
@@ -8433,7 +8433,7 @@
     },
     "log-symbols": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/l/log-symbols/_attachments/log-symbols-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/l/log-symbols/_attachments/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
@@ -8442,13 +8442,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.intuit.net/a/ansi-styles/_attachments/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/a/ansi-styles/_attachments/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.intuit.net/c/chalk/_attachments/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/c/chalk/_attachments/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -8461,7 +8461,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.intuit.net/s/strip-ansi/_attachments/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/s/strip-ansi/_attachments/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -8470,7 +8470,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.intuit.net/s/supports-color/_attachments/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/s/supports-color/_attachments/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -8546,7 +8546,7 @@
     },
     "lru-cache": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/l/lru-cache/_attachments/lru-cache-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/l/lru-cache/_attachments/lru-cache-4.1.1.tgz",
       "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
@@ -8643,7 +8643,7 @@
     },
     "mem": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/m/mem/_attachments/mem-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/m/mem/_attachments/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
@@ -8736,13 +8736,13 @@
     },
     "mime-db": {
       "version": "1.33.0",
-      "resolved": "https://registry.npmjs.intuit.net/m/mime-db/_attachments/mime-db-1.33.0.tgz",
+      "resolved": "https://registry.npmjs.org/m/mime-db/_attachments/mime-db-1.33.0.tgz",
       "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.18",
-      "resolved": "https://registry.npmjs.intuit.net/m/mime-types/_attachments/mime-types-2.1.18.tgz",
+      "resolved": "https://registry.npmjs.org/m/mime-types/_attachments/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
@@ -8751,7 +8751,7 @@
     },
     "mimic-fn": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/m/mimic-fn/_attachments/mimic-fn-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/m/mimic-fn/_attachments/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
     },
@@ -8769,7 +8769,7 @@
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.intuit.net/m/minimatch/_attachments/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/m/minimatch/_attachments/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
@@ -8778,7 +8778,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.intuit.net/m/minimist/_attachments/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/m/minimist/_attachments/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -8823,7 +8823,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.intuit.net/m/mkdirp/_attachments/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/m/mkdirp/_attachments/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -8846,7 +8846,7 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/m/ms/_attachments/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/m/ms/_attachments/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
@@ -8910,7 +8910,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.intuit.net/n/natural-compare/_attachments/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/n/natural-compare/_attachments/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
@@ -9007,7 +9007,7 @@
     },
     "normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.intuit.net/n/normalize-package-data/_attachments/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/n/normalize-package-data/_attachments/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
@@ -9019,7 +9019,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/n/normalize-path/_attachments/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/n/normalize-path/_attachments/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -9037,7 +9037,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/n/npm-run-path/_attachments/npm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/n/npm-run-path/_attachments/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -9057,7 +9057,7 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/n/number-is-nan/_attachments/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/n/number-is-nan/_attachments/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
@@ -9069,13 +9069,13 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.intuit.net/o/oauth-sign/_attachments/oauth-sign-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/o/oauth-sign/_attachments/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/o/object-assign/_attachments/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/o/object-assign/_attachments/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
@@ -9159,7 +9159,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.intuit.net/o/once/_attachments/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/o/once/_attachments/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -9168,7 +9168,7 @@
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/o/onetime/_attachments/onetime-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/o/onetime/_attachments/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
@@ -9187,7 +9187,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.intuit.net/o/optionator/_attachments/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/o/optionator/_attachments/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -9201,7 +9201,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.intuit.net/w/wordwrap/_attachments/wordwrap-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/w/wordwrap/_attachments/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
@@ -9288,7 +9288,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/o/os-homedir/_attachments/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/o/os-homedir/_attachments/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -9315,7 +9315,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/o/os-tmpdir/_attachments/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/o/os-tmpdir/_attachments/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -9336,7 +9336,7 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/p/p-finally/_attachments/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p/p-finally/_attachments/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
@@ -9348,13 +9348,13 @@
     },
     "p-limit": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/p/p-limit/_attachments/p-limit-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p/p-limit/_attachments/p-limit-1.1.0.tgz",
       "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
       "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/p/p-locate/_attachments/p-locate-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p/p-locate/_attachments/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
@@ -9449,7 +9449,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.intuit.net/p/parse-json/_attachments/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p/parse-json/_attachments/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -9482,31 +9482,31 @@
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/p/path-exists/_attachments/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p/path-exists/_attachments/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/p/path-is-absolute/_attachments/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/p/path-is-absolute/_attachments/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/p/path-is-inside/_attachments/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/p/path-is-inside/_attachments/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/p/path-key/_attachments/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/p/path-key/_attachments/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.intuit.net/p/path-parse/_attachments/path-parse-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/p/path-parse/_attachments/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
@@ -9536,13 +9536,13 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/p/performance-now/_attachments/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p/performance-now/_attachments/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.intuit.net/p/pify/_attachments/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p/pify/_attachments/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -9612,7 +9612,7 @@
     },
     "pkg-dir": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/p/pkg-dir/_attachments/pkg-dir-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p/pkg-dir/_attachments/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
@@ -9642,7 +9642,7 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.intuit.net/p/prelude-ls/_attachments/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/p/prelude-ls/_attachments/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
@@ -9702,7 +9702,7 @@
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.intuit.net/p/process-nextick-args/_attachments/process-nextick-args-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/p/process-nextick-args/_attachments/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
@@ -9736,7 +9736,7 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/p/pseudomap/_attachments/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/p/pseudomap/_attachments/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -9785,13 +9785,13 @@
     },
     "punycode": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.intuit.net/p/punycode/_attachments/punycode-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/p/punycode/_attachments/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npmjs.intuit.net/q/qs/_attachments/qs-6.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/q/qs/_attachments/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
@@ -9896,7 +9896,7 @@
     },
     "readable-stream": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.intuit.net/r/readable-stream/_attachments/readable-stream-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/r/readable-stream/_attachments/readable-stream-2.3.3.tgz",
       "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
@@ -10268,25 +10268,25 @@
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/r/remove-trailing-separator/_attachments/remove-trailing-separator-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/r/remove-trailing-separator/_attachments/remove-trailing-separator-1.0.2.tgz",
       "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.intuit.net/r/repeat-element/_attachments/repeat-element-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/r/repeat-element/_attachments/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.intuit.net/r/repeat-string/_attachments/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/r/repeat-string/_attachments/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/r/repeating/_attachments/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/r/repeating/_attachments/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -10295,7 +10295,7 @@
     },
     "request": {
       "version": "2.87.0",
-      "resolved": "https://registry.npmjs.intuit.net/r/request/_attachments/request-2.87.0.tgz",
+      "resolved": "https://registry.npmjs.org/r/request/_attachments/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
@@ -10343,19 +10343,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/r/require-directory/_attachments/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/r/require-directory/_attachments/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/r/require-main-filename/_attachments/require-main-filename-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/r/require-main-filename/_attachments/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "resolve": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.intuit.net/r/resolve/_attachments/resolve-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/r/resolve/_attachments/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
       "dev": true,
       "requires": {
@@ -10364,7 +10364,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/r/resolve-cwd/_attachments/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/r/resolve-cwd/_attachments/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -10373,7 +10373,7 @@
     },
     "resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/r/resolve-from/_attachments/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/r/resolve-from/_attachments/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
@@ -10385,7 +10385,7 @@
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/r/restore-cursor/_attachments/restore-cursor-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/r/restore-cursor/_attachments/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
@@ -10401,7 +10401,7 @@
     },
     "rimraf": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.intuit.net/r/rimraf/_attachments/rimraf-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/r/rimraf/_attachments/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
       "requires": {
@@ -10456,7 +10456,7 @@
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.intuit.net/r/rx-lite-aggregates/_attachments/rx-lite-aggregates-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/r/rx-lite-aggregates/_attachments/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
@@ -10474,7 +10474,7 @@
     },
     "safe-buffer": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.intuit.net/s/safe-buffer/_attachments/safe-buffer-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/s/safe-buffer/_attachments/safe-buffer-5.1.1.tgz",
       "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
@@ -10489,7 +10489,7 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.intuit.net/s/safer-buffer/_attachments/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/s/safer-buffer/_attachments/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
@@ -10589,7 +10589,7 @@
     },
     "semver": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.intuit.net/s/semver/_attachments/semver-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/s/semver/_attachments/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
       "dev": true
     },
@@ -10607,7 +10607,7 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/s/set-blocking/_attachments/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/s/set-blocking/_attachments/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -10673,7 +10673,7 @@
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/s/signal-exit/_attachments/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/s/signal-exit/_attachments/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
@@ -10733,13 +10733,13 @@
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/s/slash/_attachments/slash-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/s/slash/_attachments/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.intuit.net/s/slice-ansi/_attachments/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/s/slice-ansi/_attachments/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -10859,7 +10859,7 @@
     },
     "source-map": {
       "version": "0.5.6",
-      "resolved": "https://registry.npmjs.intuit.net/s/source-map/_attachments/source-map-0.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/s/source-map/_attachments/source-map-0.5.6.tgz",
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true
     },
@@ -10902,7 +10902,7 @@
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/s/spdx-correct/_attachments/spdx-correct-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/s/spdx-correct/_attachments/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
@@ -10911,13 +10911,13 @@
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.intuit.net/s/spdx-expression-parse/_attachments/spdx-expression-parse-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/s/spdx-expression-parse/_attachments/spdx-expression-parse-1.0.4.tgz",
       "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
       "dev": true
     },
     "spdx-license-ids": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.intuit.net/s/spdx-license-ids/_attachments/spdx-license-ids-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/s/spdx-license-ids/_attachments/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
@@ -10932,13 +10932,13 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.intuit.net/s/sprintf-js/_attachments/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/s/sprintf-js/_attachments/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.14.2",
-      "resolved": "https://registry.npmjs.intuit.net/s/sshpk/_attachments/sshpk-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/s/sshpk/_attachments/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
@@ -11090,7 +11090,7 @@
     },
     "string-width": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/s/string-width/_attachments/string-width-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/s/string-width/_attachments/string-width-2.1.0.tgz",
       "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
       "dev": true,
       "requires": {
@@ -11100,7 +11100,7 @@
     },
     "string_decoder": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.intuit.net/s/string_decoder/_attachments/string_decoder-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/s/string_decoder/_attachments/string_decoder-1.0.3.tgz",
       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "dev": true,
       "requires": {
@@ -11120,7 +11120,7 @@
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/s/strip-ansi/_attachments/strip-ansi-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/s/strip-ansi/_attachments/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
@@ -11129,7 +11129,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.intuit.net/a/ansi-regex/_attachments/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/a/ansi-regex/_attachments/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         }
@@ -11137,13 +11137,13 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/s/strip-bom/_attachments/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/s/strip-bom/_attachments/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/s/strip-eof/_attachments/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/s/strip-eof/_attachments/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -11164,7 +11164,7 @@
     },
     "supports-color": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.intuit.net/s/supports-color/_attachments/supports-color-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/s/supports-color/_attachments/supports-color-4.2.0.tgz",
       "integrity": "sha1-rZhtx+sjFdAJtNd8gWnCIxpoQDc=",
       "dev": true,
       "requires": {
@@ -11432,7 +11432,7 @@
     },
     "through2": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.intuit.net/t/through2/_attachments/through2-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/t/through2/_attachments/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
@@ -11463,7 +11463,7 @@
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://registry.npmjs.intuit.net/t/tmp/_attachments/tmp-0.0.33.tgz",
+      "resolved": "https://registry.npmjs.org/t/tmp/_attachments/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
@@ -11532,7 +11532,7 @@
     },
     "tough-cookie": {
       "version": "2.3.4",
-      "resolved": "https://registry.npmjs.intuit.net/t/tough-cookie/_attachments/tough-cookie-2.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/t/tough-cookie/_attachments/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
@@ -11564,7 +11564,7 @@
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/t/trim-right/_attachments/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/t/trim-right/_attachments/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
@@ -11645,7 +11645,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.intuit.net/t/tunnel-agent/_attachments/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/t/tunnel-agent/_attachments/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -11654,14 +11654,14 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.intuit.net/t/tweetnacl/_attachments/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/t/tweetnacl/_attachments/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.intuit.net/t/type-check/_attachments/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/t/type-check/_attachments/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -11670,7 +11670,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.intuit.net/t/typedarray/_attachments/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/t/typedarray/_attachments/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
@@ -11970,7 +11970,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/u/util-deprecate/_attachments/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/u/util-deprecate/_attachments/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
@@ -11986,7 +11986,7 @@
     },
     "uuid": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.intuit.net/u/uuid/_attachments/uuid-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/u/uuid/_attachments/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
     },
@@ -11998,7 +11998,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/v/validate-npm-package-license/_attachments/validate-npm-package-license-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/v/validate-npm-package-license/_attachments/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
@@ -12008,7 +12008,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.intuit.net/v/verror/_attachments/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/v/verror/_attachments/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -12616,7 +12616,7 @@
     },
     "which": {
       "version": "1.2.14",
-      "resolved": "https://registry.npmjs.intuit.net/w/which/_attachments/which-1.2.14.tgz",
+      "resolved": "https://registry.npmjs.org/w/which/_attachments/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
@@ -12625,7 +12625,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.intuit.net/w/which-module/_attachments/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/w/which-module/_attachments/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -12695,7 +12695,7 @@
     },
     "wordwrap": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/w/wordwrap/_attachments/wordwrap-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/w/wordwrap/_attachments/wordwrap-0.0.2.tgz",
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
       "dev": true
     },
@@ -12728,7 +12728,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/w/wrap-ansi/_attachments/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/w/wrap-ansi/_attachments/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -12738,7 +12738,7 @@
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.intuit.net/i/is-fullwidth-code-point/_attachments/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/i/is-fullwidth-code-point/_attachments/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -12747,7 +12747,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.intuit.net/s/string-width/_attachments/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/s/string-width/_attachments/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -12758,7 +12758,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.intuit.net/s/strip-ansi/_attachments/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/s/strip-ansi/_attachments/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -12769,7 +12769,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.intuit.net/w/wrappy/_attachments/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/w/wrappy/_attachments/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -12816,19 +12816,19 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.intuit.net/x/xtend/_attachments/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/x/xtend/_attachments/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.intuit.net/y/y18n/_attachments/y18n-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/y/y18n/_attachments/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.intuit.net/y/yallist/_attachments/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/y/yallist/_attachments/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
@@ -12854,7 +12854,7 @@
     },
     "yargs-parser": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.intuit.net/y/yargs-parser/_attachments/yargs-parser-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/y/yargs-parser/_attachments/yargs-parser-8.1.0.tgz",
       "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "webpack": ">=4.0.0"
   },
   "dependencies": {
-    "@types/loader-utils": "^1.1.3",
-    "@types/webpack": "^4.4.17",
     "loader-utils": "~1.2.3"
   },
   "devDependencies": {
     "@types/jest": "^23.3.5",
+    "@types/loader-utils": "^1.1.3",
+    "@types/webpack": "^4.4.17",
     "@typescript-eslint/parser": "2.2.0",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "all-contributors-cli": "^5.4.0",


### PR DESCRIPTION
When using tapable@2 as a normal dependency, the types that come with it conflict with those for any webpack version < 5. Moving them to devDependencies so they don't bundle in and force funky type checking.